### PR TITLE
Fix stack buffer overflow in AES-CBC test

### DIFF
--- a/projects/WjCryptLibTest/WjCryptLibTest_AesCbc.c
+++ b/projects/WjCryptLibTest/WjCryptLibTest_AesCbc.c
@@ -88,7 +88,7 @@ static TestVector gTestVectors [] =
 };
 
 #define NUM_TEST_VECTORS ( sizeof(gTestVectors) / sizeof(gTestVectors[0]) )
-#define TEST_VECTOR_OUTPUT_SIZE     48
+#define TEST_VECTOR_OUTPUT_SIZE     64
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //  INTERNAL FUNCTIONS


### PR DESCRIPTION
Hello,

While testing Pull Request https://github.com/WaterJuice/WjCryptLib/pull/7, `projects/WjCryptLibTest/WjCryptLibTest` was failing. Investing why led me to discovering a problem with the size of a stack buffer in the code which tests AES-CBC.

On x86-64, the AES-CBC test fails because the `vector` local buffer is to small to hold the encrypted test vector: the vector was created with 64 bytes while the buffer can only hold 48.

This Pull Requests increases `TEST_VECTOR_OUTPUT_SIZE` to 64 to fix this issue.